### PR TITLE
Update composer.json to support Symfony 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifndef PHP
 	PHP=7.2
 endif
 ifndef PHPUNIT
-	PHPUNIT=8.2
+	PHPUNIT=8.3
 endif
 
 qa_image=jakzal/phpqa:php${PHP}-alpine

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ phpunit-coverage:
 	${qa} phpdbg -qrr /tools/simple-phpunit ${phpunit_args} --coverage-clover=var/coverage.xml
 phpunit-pull:
 	rm -rf var/phpunit
-	${qa} sh -c "cp -RL /tools/.composer/vendor-bin/symfony/vendor/bin/.phpunit/phpunit-${PHPUNIT} var/phpunit"
+	${qa} sh -c "cp -RL /tools/.composer/vendor-bin/symfony/vendor/bin/.phpunit/phpunit-${PHPUNIT}-0 var/phpunit"
 
 # code style
 cs:

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
     ],
     "require": {
         "php": "^7.2",
-        "symfony/http-foundation": "^3.4 || ^4.2"
+        "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0"
     },
     "require-dev": {
         "fig/link-util": "^1.0",
-        "symfony/config": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/http-kernel": "^3.4 || ^4.2",
-        "symfony/routing": "^3.4 || ^4.2",
-        "twig/twig": "^1.34 || ^2.0"
+        "symfony/config": "^3.4 || ^4.2 || ^5.0",
+        "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0",
+        "symfony/routing": "^3.4 || ^4.2 || ^5.0",
+        "twig/twig": "^1.34 || ^2.0 || ^3.0"
     },
     "config": {
         "preferred-install": {

--- a/src/Test/ResponderTestCase.php
+++ b/src/Test/ResponderTestCase.php
@@ -164,7 +164,12 @@ abstract class ResponderTestCase extends TestCase
             ->withLink('href2', ['rel', 'rel2'])
             ->withLink('href3', ['rel'], ['a' => true, 'b', 'c' => 'foo bar', 'd' => false, 'e' => 'boo', 'f' => 'f']));
 
-        self::assertSame(['custom', '<href>; rel="", <href2>; rel="rel rel2", <href3>; rel="rel"; a; b; c="foo bar"; e="boo"; f'], $response->headers->get('link', null, false));
+        $reflectionMethod = new \ReflectionMethod($response->headers, 'all');
+        $actual = $reflectionMethod->getNumberOfParameters() === 1
+            ? $response->headers->all('link')
+            : $response->headers->get('link', null, false);
+
+        self::assertSame(['custom', '<href>; rel="", <href2>; rel="rel rel2", <href3>; rel="rel"; a; b; c="foo bar"; e="boo"; f'], $actual);
     }
 
     public function testRespondUnknown(): void

--- a/src/Test/ResponderTestCase.php
+++ b/src/Test/ResponderTestCase.php
@@ -165,7 +165,7 @@ abstract class ResponderTestCase extends TestCase
             ->withLink('href3', ['rel'], ['a' => true, 'b', 'c' => 'foo bar', 'd' => false, 'e' => 'boo', 'f' => 'f']));
 
         $reflectionMethod = new \ReflectionMethod($response->headers, 'all');
-        $actual = $reflectionMethod->getNumberOfParameters() === 1
+        $actual = 1 === $reflectionMethod->getNumberOfParameters()
             ? $response->headers->all('link')
             : $response->headers->get('link', null, false);
 


### PR DESCRIPTION
This PR aims to make the bundle compatible with Symfony 5.
The only deprecation I encountered in version 4.4 is :

> Symfony\Component\DependencyInjection\Loader\Configurator\tagged() is deprecated since Symfony 4.4 and will be removed in 5.0, use Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator() instead.

This deprecation seems fixed in the master branch. So if you accept this PR, the bundle should be fully compatible with Symfony 5.